### PR TITLE
bugfix invalid call to getTaxonomicNote()

### DIFF
--- a/taxon_parser/name_parser_api/util/nameformatter.py
+++ b/taxon_parser/name_parser_api/util/nameformatter.py
@@ -201,7 +201,7 @@ def buildName(n, hybridMarker, rankMarker, authorship, genusForinfrageneric, inf
             sb += " '" + n.cultivarEpithet + "'"    
 
     # add sensu/sec reference
-    if showSensu and n.getTaxonomicNote() is not None:
+    if showSensu and n.taxonomicNote is not None:
         if sb != '':
             sb += " "
         sb += n.taxonomicNote   


### PR DESCRIPTION
Hi,

when doing this:

```
taxon_parser = TaxonParser('Zinnia elegans Jacq.')
parsed_name = taxon_parser.parse()
parsed_name.canonicalNameComplete()
```
I get the following error: 

*** AttributeError: 'ParsedName' object has no attribute 'getTaxonomicNote'

It seems to me the error can be solved by replacing __getTaxonomicNote()__ with __taxonomicNote__ here:

https://github.com/aroche/taxon_parser/blob/05319ab1c7f1df706f184fe6ef406e791403790d/taxon_parser/name_parser_api/util/nameformatter.py#L204

Thanks for the parser, I still like it :)

best
Tobias